### PR TITLE
feat: NewsAPI Configuration in Settings

### DIFF
--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -6,6 +6,29 @@ import { handleApiError, validateEnum } from '@/lib/errorHandler'
 // Force Node.js runtime (required for crypto module in cacheHeaders)
 export const runtime = 'nodejs'
 
+// Valid NewsAPI values
+const VALID_NEWSAPI_CATEGORIES = [
+  'business', 'entertainment', 'general', 'health', 'science', 'sports', 'technology'
+] as const
+
+const VALID_NEWSAPI_LANGUAGES = [
+  'ar', 'de', 'en', 'es', 'fr', 'he', 'it', 'nl', 'no', 'pt', 'ru', 'sv', 'ud', 'zh'
+] as const
+
+const VALID_NEWSAPI_COUNTRIES = [
+  'ae', 'ar', 'at', 'au', 'be', 'bg', 'br', 'ca', 'ch', 'cn', 'co', 'cu', 'cz', 'de',
+  'eg', 'fr', 'gb', 'gr', 'hk', 'hu', 'id', 'ie', 'il', 'in', 'it', 'jp', 'kr', 'lt',
+  'lv', 'ma', 'mx', 'my', 'ng', 'nl', 'no', 'nz', 'ph', 'pl', 'pt', 'ro', 'rs', 'ru',
+  'sa', 'se', 'sg', 'si', 'sk', 'th', 'tr', 'tw', 'ua', 'us', 've', 'za'
+] as const
+
+// Validate comma-separated categories
+function validateCategories(categories: string): boolean {
+  if (!categories) return true
+  const categoryList = categories.split(',').map(c => c.trim())
+  return categoryList.every(cat => VALID_NEWSAPI_CATEGORIES.includes(cat as typeof VALID_NEWSAPI_CATEGORIES[number]))
+}
+
 // GET /api/settings - Get user settings
 export async function GET(request: Request) {
   try {
@@ -14,7 +37,13 @@ export async function GET(request: Request) {
     // Create default settings if none exist
     if (!settings) {
       settings = await prisma.userSettings.create({
-        data: { diversityLevel: 'medium' },
+        data: {
+          diversityLevel: 'medium',
+          newsApiEnabled: true,
+          newsApiCategories: 'technology,science,business',
+          newsApiLanguage: 'en',
+          newsApiCountry: 'us'
+        },
       })
     }
 
@@ -29,24 +58,74 @@ export async function GET(request: Request) {
 export async function PATCH(request: Request) {
   try {
     const body = await request.json()
-    const { diversityLevel } = body
+    const {
+      diversityLevel,
+      newsApiEnabled,
+      newsApiCategories,
+      newsApiLanguage,
+      newsApiCountry
+    } = body
 
     // Validate diversity level using centralized validation
     if (diversityLevel) {
       validateEnum(diversityLevel, ['low', 'medium', 'high'] as const, 'diversityLevel')
     }
 
+    // Validate NewsAPI categories
+    if (newsApiCategories !== undefined && newsApiCategories !== '') {
+      if (!validateCategories(newsApiCategories)) {
+        return NextResponse.json(
+          { error: `Invalid newsApiCategories. Valid categories: ${VALID_NEWSAPI_CATEGORIES.join(', ')}` },
+          { status: 400 }
+        )
+      }
+    }
+
+    // Validate NewsAPI language
+    if (newsApiLanguage !== undefined && newsApiLanguage !== '') {
+      if (!VALID_NEWSAPI_LANGUAGES.includes(newsApiLanguage as typeof VALID_NEWSAPI_LANGUAGES[number])) {
+        return NextResponse.json(
+          { error: `Invalid newsApiLanguage. Valid languages: ${VALID_NEWSAPI_LANGUAGES.join(', ')}` },
+          { status: 400 }
+        )
+      }
+    }
+
+    // Validate NewsAPI country
+    if (newsApiCountry !== undefined && newsApiCountry !== '') {
+      if (!VALID_NEWSAPI_COUNTRIES.includes(newsApiCountry as typeof VALID_NEWSAPI_COUNTRIES[number])) {
+        return NextResponse.json(
+          { error: `Invalid newsApiCountry. Valid countries: ${VALID_NEWSAPI_COUNTRIES.join(', ')}` },
+          { status: 400 }
+        )
+      }
+    }
+
     // Get or create settings
     let settings = await prisma.userSettings.findFirst()
 
+    // Build update data - only include fields that were provided
+    const updateData: Record<string, string | boolean> = {}
+    if (diversityLevel) updateData.diversityLevel = diversityLevel
+    if (newsApiEnabled !== undefined) updateData.newsApiEnabled = Boolean(newsApiEnabled)
+    if (newsApiCategories !== undefined && newsApiCategories !== '') updateData.newsApiCategories = newsApiCategories
+    if (newsApiLanguage !== undefined && newsApiLanguage !== '') updateData.newsApiLanguage = newsApiLanguage
+    if (newsApiCountry !== undefined && newsApiCountry !== '') updateData.newsApiCountry = newsApiCountry
+
     if (!settings) {
       settings = await prisma.userSettings.create({
-        data: { diversityLevel: diversityLevel || 'medium' },
+        data: {
+          diversityLevel: diversityLevel || 'medium',
+          newsApiEnabled: newsApiEnabled ?? true,
+          newsApiCategories: newsApiCategories || 'technology,science,business',
+          newsApiLanguage: newsApiLanguage || 'en',
+          newsApiCountry: newsApiCountry || 'us'
+        },
       })
     } else {
       settings = await prisma.userSettings.update({
         where: { id: settings.id },
-        data: { diversityLevel: diversityLevel || settings.diversityLevel },
+        data: updateData,
       })
     }
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import SettingsPanel from '@/components/SettingsPanel'
+
+export default function SettingsPage() {
+  return (
+    <div className="min-h-screen bg-neutral-900 p-6">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold text-neutral-100 mb-6">Settings</h1>
+        <SettingsPanel />
+      </div>
+    </div>
+  )
+}

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface UserSettings {
+  id: string
+  diversityLevel: string
+  newsApiEnabled: boolean
+  newsApiCategories: string
+  newsApiLanguage: string
+  newsApiCountry: string
+  createdAt: string
+  updatedAt: string
+}
+
+const DIVERSITY_LEVELS = ['low', 'medium', 'high'] as const
+const NEWSAPI_CATEGORIES = [
+  'business', 'entertainment', 'general', 'health', 'science', 'sports', 'technology'
+] as const
+const NEWSAPI_LANGUAGES = [
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+  { code: 'it', name: 'Italian' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'zh', name: 'Chinese' },
+  { code: 'ar', name: 'Arabic' },
+  { code: 'nl', name: 'Dutch' },
+  { code: 'no', name: 'Norwegian' },
+  { code: 'sv', name: 'Swedish' },
+] as const
+const NEWSAPI_COUNTRIES = [
+  { code: 'us', name: 'United States' },
+  { code: 'gb', name: 'United Kingdom' },
+  { code: 'ca', name: 'Canada' },
+  { code: 'au', name: 'Australia' },
+  { code: 'de', name: 'Germany' },
+  { code: 'fr', name: 'France' },
+  { code: 'it', name: 'Italy' },
+  { code: 'es', name: 'Spain' },
+  { code: 'nl', name: 'Netherlands' },
+  { code: 'br', name: 'Brazil' },
+  { code: 'in', name: 'India' },
+  { code: 'jp', name: 'Japan' },
+  { code: 'cn', name: 'China' },
+  { code: 'mx', name: 'Mexico' },
+] as const
+
+export default function SettingsPanel() {
+  const [settings, setSettings] = useState<UserSettings | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  // Form state
+  const [diversityLevel, setDiversityLevel] = useState('medium')
+  const [newsApiEnabled, setNewsApiEnabled] = useState(true)
+  const [selectedCategories, setSelectedCategories] = useState<string[]>(['technology', 'science', 'business'])
+  const [newsApiLanguage, setNewsApiLanguage] = useState('en')
+  const [newsApiCountry, setNewsApiCountry] = useState('us')
+
+  useEffect(() => {
+    fetchSettings()
+  }, [])
+
+  const fetchSettings = async () => {
+    try {
+      const response = await fetch('/api/settings')
+      const data = await response.json()
+      setSettings(data)
+      setDiversityLevel(data.diversityLevel || 'medium')
+      setNewsApiEnabled(data.newsApiEnabled ?? true)
+      setSelectedCategories(data.newsApiCategories?.split(',') || ['technology', 'science', 'business'])
+      setNewsApiLanguage(data.newsApiLanguage || 'en')
+      setNewsApiCountry(data.newsApiCountry || 'us')
+    } catch (error) {
+      console.error('Failed to fetch settings:', error)
+      setMessage({ type: 'error', text: 'Failed to load settings' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setMessage(null)
+
+    try {
+      const response = await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          diversityLevel,
+          newsApiEnabled,
+          newsApiCategories: selectedCategories.join(','),
+          newsApiLanguage,
+          newsApiCountry,
+        }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || 'Failed to save settings')
+      }
+
+      const data = await response.json()
+      setSettings(data)
+      setMessage({ type: 'success', text: 'Settings saved successfully' })
+    } catch (error) {
+      console.error('Failed to save settings:', error)
+      setMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to save settings' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const toggleCategory = (category: string) => {
+    setSelectedCategories(prev =>
+      prev.includes(category)
+        ? prev.filter(c => c !== category)
+        : [...prev, category]
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="glass-card p-6 rounded-lg">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 bg-neutral-700 rounded w-1/4"></div>
+          <div className="h-10 bg-neutral-700 rounded"></div>
+          <div className="h-4 bg-neutral-700 rounded w-1/3"></div>
+          <div className="h-10 bg-neutral-700 rounded"></div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Message Banner */}
+      {message && (
+        <div className={`p-4 rounded-lg ${message.type === 'success' ? 'bg-green-900/50 text-green-200' : 'bg-red-900/50 text-red-200'}`}>
+          {message.text}
+        </div>
+      )}
+
+      {/* Feed Personalization Section */}
+      <div className="glass-card p-6 rounded-lg">
+        <h2 className="text-lg font-semibold text-neutral-100 mb-4">Feed Personalization</h2>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-neutral-300 mb-2">
+              Diversity Level
+            </label>
+            <p className="text-xs text-neutral-500 mb-2">
+              Controls how diverse your feed sources are. Higher = more variety from different sources.
+            </p>
+            <div className="flex gap-2">
+              {DIVERSITY_LEVELS.map(level => (
+                <button
+                  key={level}
+                  onClick={() => setDiversityLevel(level)}
+                  className={`px-4 py-2 rounded-lg capitalize transition-colors ${
+                    diversityLevel === level
+                      ? 'bg-ember-500 text-white'
+                      : 'bg-neutral-700 text-neutral-300 hover:bg-neutral-600'
+                  }`}
+                >
+                  {level}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* NewsAPI Configuration Section */}
+      <div className="glass-card p-6 rounded-lg">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-neutral-100">NewsAPI Configuration</h2>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <span className="text-sm text-neutral-400">
+              {newsApiEnabled ? 'Enabled' : 'Disabled'}
+            </span>
+            <div
+              onClick={() => setNewsApiEnabled(!newsApiEnabled)}
+              className={`relative w-12 h-6 rounded-full transition-colors ${
+                newsApiEnabled ? 'bg-ember-500' : 'bg-neutral-600'
+              }`}
+            >
+              <div
+                className={`absolute top-1 w-4 h-4 bg-white rounded-full transition-transform ${
+                  newsApiEnabled ? 'translate-x-7' : 'translate-x-1'
+                }`}
+              />
+            </div>
+          </label>
+        </div>
+
+        <div className={`space-y-4 ${!newsApiEnabled ? 'opacity-50 pointer-events-none' : ''}`}>
+          {/* Categories */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-300 mb-2">
+              News Categories
+            </label>
+            <p className="text-xs text-neutral-500 mb-2">
+              Select which news categories to include in your feed.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {NEWSAPI_CATEGORIES.map(category => (
+                <button
+                  key={category}
+                  onClick={() => toggleCategory(category)}
+                  className={`px-3 py-1.5 rounded-lg text-sm capitalize transition-colors ${
+                    selectedCategories.includes(category)
+                      ? 'bg-ember-500 text-white'
+                      : 'bg-neutral-700 text-neutral-300 hover:bg-neutral-600'
+                  }`}
+                >
+                  {category}
+                </button>
+              ))}
+            </div>
+            {selectedCategories.length === 0 && (
+              <p className="text-xs text-amber-400 mt-2">
+                Select at least one category
+              </p>
+            )}
+          </div>
+
+          {/* Language */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-300 mb-2">
+              Language
+            </label>
+            <select
+              value={newsApiLanguage}
+              onChange={(e) => setNewsApiLanguage(e.target.value)}
+              className="w-full bg-neutral-700 text-neutral-100 rounded-lg px-4 py-2 border border-neutral-600 focus:border-ember-500 focus:outline-none"
+            >
+              {NEWSAPI_LANGUAGES.map(lang => (
+                <option key={lang.code} value={lang.code}>
+                  {lang.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Country */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-300 mb-2">
+              Country
+            </label>
+            <p className="text-xs text-neutral-500 mb-2">
+              Get top headlines from this country.
+            </p>
+            <select
+              value={newsApiCountry}
+              onChange={(e) => setNewsApiCountry(e.target.value)}
+              className="w-full bg-neutral-700 text-neutral-100 rounded-lg px-4 py-2 border border-neutral-600 focus:border-ember-500 focus:outline-none"
+            >
+              {NEWSAPI_COUNTRIES.map(country => (
+                <option key={country.code} value={country.code}>
+                  {country.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Save Button */}
+      <div className="flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={saving || selectedCategories.length === 0}
+          className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+            saving || selectedCategories.length === 0
+              ? 'bg-neutral-600 text-neutral-400 cursor-not-allowed'
+              : 'bg-ember-500 text-white hover:bg-ember-600'
+          }`}
+        >
+          {saving ? 'Saving...' : 'Save Settings'}
+        </button>
+      </div>
+
+      {/* Last Updated */}
+      {settings && (
+        <p className="text-xs text-neutral-500 text-center">
+          Last updated: {new Date(settings.updatedAt).toLocaleString()}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -183,6 +183,13 @@ model SavedArticle {
 model UserSettings {
   id              String   @id @default(cuid())
   diversityLevel  String   @default("medium") // "low", "medium", "high"
+
+  // NewsAPI Configuration
+  newsApiEnabled    Boolean @default(true)
+  newsApiCategories String  @default("technology,science,business") // comma-separated list
+  newsApiLanguage   String  @default("en")  // ISO 639-1 language code
+  newsApiCountry    String  @default("us")  // ISO 3166-1 alpha-2 country code
+
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
Implements #43 - NewsAPI configuration in settings page

- Extended UserSettings schema with NewsAPI fields (enabled, categories, language, country)
- Added PATCH /api/settings support for NewsAPI configuration with validation
- Created /settings page with SettingsPanel component
- UI includes diversity level toggle and full NewsAPI configuration

## Changes
- `prisma/schema.prisma` - Add NewsAPI fields to UserSettings
- `app/api/settings/route.ts` - Extend PATCH handler with validation
- `app/settings/page.tsx` - New Settings page
- `components/SettingsPanel.tsx` - New settings form component
- `tests/api/settings.spec.ts` - 12 new tests for NewsAPI settings

## Test plan
- [x] All 29 settings API tests pass
- [x] Lint passes (0 errors)
- [x] TypeScript compiles
- [ ] Manual: Navigate to /settings, verify form loads
- [ ] Manual: Toggle NewsAPI enabled/disabled
- [ ] Manual: Select categories and save
- [ ] Manual: Change language/country and save

🤖 Generated with [Claude Code](https://claude.com/claude-code)